### PR TITLE
Update all motor sims in wrappers

### DIFF
--- a/build_scripts/base_java_publish.gradle
+++ b/build_scripts/base_java_publish.gradle
@@ -33,7 +33,7 @@ publishing {
 
         snobot_sim_java(MavenPublication) {
             groupId 'org.snobotv2'
-            version '2022.1.0.0'
+            version '2022.1.1.0'
 
             artifact jar
             artifact javadocJar

--- a/snobot_sim_java/src/main/java/org/snobotv2/sim_wrappers/InstantaneousMotorSim.java
+++ b/snobot_sim_java/src/main/java/org/snobotv2/sim_wrappers/InstantaneousMotorSim.java
@@ -17,6 +17,8 @@ public class InstantaneousMotorSim extends BaseSingleGearboxSimWrapper
     @Override
     public void update()
     {
+        mMotor.update();
+
         double velocity = mMotor.getVoltagePercentage() * mMaxSpeed;
         mPosition += velocity * mUpdatePeriod;
 

--- a/snobot_sim_java/src/main/java/org/snobotv2/sim_wrappers/SingleJointedArmSimWrapper.java
+++ b/snobot_sim_java/src/main/java/org/snobotv2/sim_wrappers/SingleJointedArmSimWrapper.java
@@ -40,6 +40,8 @@ public class SingleJointedArmSimWrapper extends BaseSingleGearboxSimWrapper
     @Override
     public void update()
     {
+        mMotor.update();
+
         // In this method, we update our simulation of what our elevator is doing
         // First, we set our "inputs" (voltages)
         mArmSim.setInput(mMotor.getVoltagePercentage() * RobotController.getBatteryVoltage());
@@ -47,8 +49,10 @@ public class SingleJointedArmSimWrapper extends BaseSingleGearboxSimWrapper
         // Next, we update it. The standard loop time is 20ms.
         mArmSim.update(mUpdatePeriod);
 
+
         // Finally, we set our simulated encoder's readings and simulated battery voltage
         mEncoderWrapper.setDistance(mArmSim.getAngleRads());
+        mEncoderWrapper.setVelocity(mArmSim.getVelocityRadPerSec());
 
         mMotor.setCurrent(mArmSim.getCurrentDrawAmps());
         mPdpSlots.update(mPdpModule, mArmSim.getCurrentDrawAmps());


### PR DESCRIPTION
The `update` method must be called for simulators, especially when using SparkMax's. Otherwise the simulation variables do not get updated.